### PR TITLE
Update version to 0.0.2

### DIFF
--- a/serveit
+++ b/serveit
@@ -6,7 +6,7 @@ require "open3"
 require "optparse"
 
 class ServeIt
-  VERSION = [0, 0, 1]
+  VERSION = [0, 0, 2]
   def self.main
     serve_dir, ignored_paths, command = parse_opts
     serve_dir = File.expand_path(serve_dir)


### PR DESCRIPTION
[Since 0.0.1](https://github.com/garybernhardt/serveit/compare/v0.0.1...master), `serveit` has gotten [the ability to ignore paths via the `-i` command-line switch](https://github.com/garybernhardt/serveit/commit/cb8070a2b2a0751388c9ef65549ac0c27f5c0712). This is mentioned in the README, and if the script is downloaded raw from the `master` branch, it works.

However, `brew install serveit` installs the release 0.0.1. That version does not support `-i`, so this can lead to some head-scratching by someone who just wants to use `serveit`. I came across this issue when looking to use [your `rebuild` gist](https://gist.github.com/garybernhardt/63c21e45e18dba4e1eaddd4d09debaef) as a skeleton for my own project.

Hence, I am proposing a version update to 0.0.2, so that the homebrew formula can be updated, and so that there’s a stable release which includes all documented features. This PR only includes an update to `ServeIt::VERSION`, so it needs to be follwed by a release (I am assuming through `bin/release`).

Cheers and thanks for your work—`serveit` is great!