### PR TITLE
Ignore lock files and other dead symlinks

### DIFF
--- a/serveit
+++ b/serveit
@@ -177,7 +177,7 @@ class ServeIt
       Find.find(".") do |path|
         if ignore_path?(path)
           Find.prune
-        elsif lock_file?(path)
+        elsif missing_symlink_target?(path)
           next
         else
           paths << path
@@ -191,9 +191,12 @@ class ServeIt
       end
     end
 
-    def lock_file?(path)
-      File.symlink?(path) \
-                   and not File.exist?(File.join(File.dirname(path), File.readlink(path)))
+    def missing_symlink_target?(path)
+      is_symlink = File.symlink?(path)
+      return false unless is_symlink
+
+      full_symlink_path = File.join(File.dirname(path), File.readlink(path))
+      return (not File.exist?(full_symlink_path))
     end
 
     def ignore_path?(path)

--- a/serveit
+++ b/serveit
@@ -177,6 +177,8 @@ class ServeIt
       Find.find(".") do |path|
         if ignore_path?(path)
           Find.prune
+        elsif lock_file?(path)
+          next
         else
           paths << path
         end
@@ -187,6 +189,11 @@ class ServeIt
       end.sort.tap do
         puts (" scanned in %.03fs" % (Time.now - start_time)).rjust(80, "=")
       end
+    end
+
+    def lock_file?(path)
+      File.symlink?(path) \
+                   and not File.exist?(File.join(File.dirname(path), File.readlink(path)))
     end
 
     def ignore_path?(path)


### PR DESCRIPTION
Emacs creates lock files — symbolic links which contain a process identifier — when you start modifying a file but haven’t yet saved it. These would cause serveit to produce a 500 error, because it tries to stat the referent of these symlinks, which is by design a nonexistent file.

More generally this will stop the server coming up with a 500 error whenever the directory structure which is being watched contains a symbolic link to a file which doesn’t exist.