### PR TITLE
Dir encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ ServeIt is serving the `build` directory because of the `-s` argument, so I see 
 You can ignore files or directories with `-i YOUR_IGNORED_DIR`.
 Specify it multiple times to ignore multiple paths.
 
+You can change the port ServeIt serves on using the `-p` argument.
+
 ## Practicalities
 
 ServeIt requires Ruby 1.9.3 or later, but has no other dependencies.

--- a/serveit
+++ b/serveit
@@ -69,6 +69,7 @@ class ServeIt
       server = WEBrick::HTTPServer.new(:Port => @port)
 
       server.mount_proc '/' do |req, res|
+        res['Access-Control-Allow-Origin'] = '*'
         relative_path = req.path.sub(/^\//, '')
         local_abs_path = File.absolute_path(relative_path, @serve_dir)
 

--- a/serveit
+++ b/serveit
@@ -110,12 +110,14 @@ class ServeIt
     def respond_to_dir(res, rel_path, local_abs_path)
       res.content_type = "text/html"
       res.body = (
+        "<meta charset=\"utf-8\"/>" +
         "<p><h3>Listing for /#{rel_path}</h3></p>\n" +
         Dir.entries(local_abs_path).select do |child|
           child != "."
         end.sort.map do |child|
-          full_child_path_on_server = File.join("/", rel_path, child)
-          %{<a href="#{full_child_path_on_server}">#{child}</a><br>}
+          utf8_child = child.encode('utf-8')
+          full_child_path_on_server = File.join("/", rel_path, utf8_child)
+          %{<a href="#{full_child_path_on_server}">#{utf8_child}</a><br>}
         end.join("\n")
       )
     end

--- a/serveit
+++ b/serveit
@@ -95,8 +95,18 @@ class ServeIt
         return respond_to_error(res, e.to_s)
       end
 
+      if local_abs_path.end_with?("__dir__")
+        return respond_to_dir(res,
+                              relative_path.chomp("/").chomp("__dir__"),
+                              local_abs_path.chomp("/").chomp("__dir__"))
+      end
+
       if File.directory?(local_abs_path)
-        respond_to_dir(res, relative_path, local_abs_path)
+        if File.file?(local_abs_path + "/index.html")
+          respond_to_file(res, local_abs_path + "/index.html")
+        else
+          respond_to_dir(res, relative_path, local_abs_path)
+        end
       else
         # We're building a file
         respond_to_file(res, local_abs_path)


### PR DESCRIPTION
Currently non-ascii filenames are displayed incorrectly when viewing directory listings in the browser. This update transcodes filenames from the system encoding to utf-8 and sets the html encoding to utf-8.

Before:
<img width="260" alt="before" src="https://user-images.githubusercontent.com/3614633/55685142-75842000-595b-11e9-89b8-2b1767e9fcd0.png">

After:
<img width="260" alt="after" src="https://user-images.githubusercontent.com/3614633/55685144-79b03d80-595b-11e9-8a62-3cf4c7c5b94a.png">

I also added documentation for `-p` to the readme.

Thanks!