### PR TITLE
Support binding to custom local address

### DIFF
--- a/serveit
+++ b/serveit
@@ -9,19 +9,23 @@ class ServeIt
   VERSION = [0, 0, 3]
 
   def self.main
-    serve_dir, port, ignored_paths, command = parse_opts
+    serve_dir, addr, port, ignored_paths, command = parse_opts
     serve_dir = File.expand_path(serve_dir)
-    Server.new(serve_dir, port, ignored_paths, command).serve
+    Server.new(serve_dir, addr, port, ignored_paths, command).serve
   end
 
   def self.parse_opts
     options = {:serve_dir => ".",
                :ignored_paths =>  [],
+               :addr => "localhost",
                :port => 8000}
     parser = OptionParser.new do |opts|
       opts.banner = "Usage: #{$PROGRAM_NAME} [options] command"
       opts.on_tail("-s", "--serve-dir DIR", "Root directory for server") do |dir|
         options[:serve_dir] = dir
+      end
+      opts.on_tail("-a", "--address ADDR", "Local address to bind to") do |addr|
+        options[:addr] = addr
       end
       opts.on_tail("-p", "--port PORT", Integer, "TCP port number to listen on") do |port|
         options[:port] = port
@@ -52,21 +56,22 @@ class ServeIt
       exit 1
     end
 
-    [options.fetch(:serve_dir), options.fetch(:port), options.fetch(:ignored_paths), command]
+    [options.fetch(:serve_dir), options.fetch(:addr), options.fetch(:port), options.fetch(:ignored_paths), command]
   end
 
   class Server
-    def initialize(serve_dir, port, ignored_paths, command)
+    def initialize(serve_dir, addr, port, ignored_paths, command)
       @mutex = Mutex.new
       @serve_dir = serve_dir
+      @addr = addr
       @port = port
       @command = command
       @rebuilder = Rebuilder.new(@command, ignored_paths) if @command
     end
 
     def serve
-      puts "Starting server at http://localhost:#{@port}"
-      server = WEBrick::HTTPServer.new(:Port => @port)
+      puts "Starting server at http://#{@addr}:#{@port}"
+      server = WEBrick::HTTPServer.new(:BindAddress => @addr, :Port => @port)
 
       server.mount_proc '/' do |req, res|
         relative_path = req.path.sub(/^\//, '')


### PR DESCRIPTION
Motivation: my machine has a local WireGuard interface with associated IP address, and I'd like ServeIt to bind to that address rather than `localhost` so that I can connect from my other devices as well. This is a slightly eccentric use-case, so feel free to close if you think it's not worth supporting.